### PR TITLE
Add a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+<!-- TODO: Decide who will handle Code of Conduct reports and replace [INSERT EMAIL ADDRESS]
+    with an email address in the paragraph below. We recommend using a mailing list to handle reports. 
+-->
+Please contact [INSERT EMAIL ADDRESS] or the Linux Foundation mediator, Mishi Choudhary mishi@linux.com
+to report an issue.


### PR DESCRIPTION
~Use the Contributor Covenant 1.4 as a well accepted template for a Code of Conduct for CNCF projects.~

Have the Code of Conduct link to the CNCF Code of Conduct. 