### PR TITLE
Add two initial governance templates.

### DIFF
--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -1,0 +1,294 @@
+# Steering Committee Governance
+
+This is an example governance document for projects that use steering committee
+elections from the contributors at large.  See [GOVERNANCE.md](/GOVERNANCE.md)
+for more information.  Thanks to the Kubernetes Project for portions of the text
+below.
+
+This is a template document for CNCF projects that requires editing
+before it is ready to use. Read the markdown comments, `<!-- COMMENT -->`, for
+additional guidance. The raw markdown uses `TODO` to identify areas that
+require customization.  Replace [TODO: PROJECTNAME] with the name of your project.
+
+<!-- template begins here-->
+
+The [TODO: PROJECTNAME] Steering Committee is the governing body of the [TODO: PROJECTNAME] project,
+providing decision-making and oversight pertaining to the project bylaws,
+sub-organizations, and financial planning. The Steering Committee also defines
+the project values and structure.
+
+This governance  is an open, living document, and will continue to
+evolve as the community and project change.
+
+- [Charter](#charter)
+- [Delegated authority](#delegated-authority)
+- [Committee Meetings](#committee-meetings)
+- [Committee Members](#committee-members)
+- [Decision process](#decision-process)
+- [Getting in touch](#getting-in-touch)
+- [Elections](#election-procedure)
+  - [Timeline](#timeline)
+  - [Election Officer(s)](#election-officers)
+  - [Eligibility to Vote](#eligibility-to-vote)
+  - [Candidate Eligibility](#candidate-eligibility)
+  - [Voting Procedure](#voting-procedure)
+  - [Limitations on Company Representation](#limitations-on-company-representation)
+- [Vacancies](#vacancies)
+- [Changes to the charter](#changes-to-the-charter)
+- [Authority, Facilitation, and Decision Making](#authority-facilitation-and-decision-making)
+
+## Charter
+
+The following responsibilities and powers belong to the Steering Committee.
+
+Technical governance is expected to be performed by the Maintainers of the
+various project areas and subprojects, as defined in the appropriate OWNERS files.
+
+* Delegate ownership of, responsibility for and authority over areas of the
+  project to specific entities.
+* Define, evolve, and defend the vision, mission and the values of the project.
+* Charter and refine policy for defining new community groups, and establish
+  transparency and accountability policies for such groups
+* Define and evolve project and group governance structures and policies.
+* Act as a final escalation point for disputes in any project repository or
+  group.
+* Request funds and other support from the CNCF (e.g. marketing, press, etc.)
+* Coordinate with the CNCF regarding usage of the [TODO: PROJECTNAME] brand and deciding
+  project scope, core requirements, and conformance, as well as how that brand
+  can be used in relation to other efforts or vendors.
+* Decide, for the purpose of elections, who is a member of standing, and what
+  privileges that entails.
+* Control and delegate access to and establish processes regarding all project
+  repositories, resources, and assets.
+<!-- assumes a separate Code of Conduct Committee, which is expected for
+ any project mature enough to need a Steering Committee-->
+* Appointing the members of the Code of Conduct Committee in order to ensure
+  responsiveness, diversity, and good judgement.
+
+## Delegated authority
+
+The Steering Committee may choose to delegate its authority to other committees
+as-needed. The committee currently recognizes this delegated authority for:
+
+- [TODO: List of Delegated Authorities]
+
+<!-- Above put a list of powers of the SC that are being handled by some other
+group or person.  For example, you may have a Marketing Committee that handles
+all work with CNCF marketing, or a different body that handles escalated
+technical disputes.-->
+
+## Committee Meetings
+
+The Steering Committee meets [TODO: frequency of meetings], or as-needed.
+Meetings are held online, and are public by default.
+
+Given the private nature of some of these discussions (e.g. privacy, private
+emails to the committee, code of conduct violations, escalations, disputes
+between members, security reports, etc.) some meetings are held in private.
+<!-- consider setting up a cadence of private vs. public meetings here-->
+
+Meeting notes are available to members of the
+[developer mailing list](TODO).
+Public meetings will be recorded and the recordings made available publicly.
+
+Questions and proposals for changes to governance or community procedures are posted as
+[issues in the community repo](TODO), and
+the Steering Committee invites your feedback there. See
+[Getting in touch](#getting-in-touch) for other options.
+
+## Committee members
+
+Seats on the Steering Committee are held by an individual, not by their
+employer.
+
+The current membership of the committee is currently (listed alphabetically by
+first name):
+
+| &nbsp;                                                         | Member           | Organization |
+| -------------------------------------------------------------- | ---------------- | ------------ |
+
+
+## Decision process
+
+The Steering Committee desires to always reach consensus.
+
+Decisions requiring a vote include: issuing written policy, amending existing
+written policy, creating, removing, or modifying a working group, all spending,
+hiring, and contracting, official responses to publicly raised issues, or any
+other decisions that at least two of the members present decide require a vote.
+
+Decisions are made in meetings when a quorum of more than half of the members
+are present (and all members have been informed of the meeting), and may pass
+with more than half the members of the committee supporting it.
+
+## Getting in touch
+
+There are two ways to raise issues to the steering committee for decision:
+
+1. Emailing the Steering Committee at
+   [steering@project.org](TODO).
+   This is a private discussion list to which all members of the committee have
+   access.
+2. Open an issue on [the community repository](TODO) and indicate that you would like
+   attention from the steering committee.
+
+## Composition
+
+The steering committee has [TODO: Number] seats. These seats are
+open to any project contributor. See
+[candidate eligibility](#candidate-eligibility) for a definition.
+
+<!-- if doing staggered terms, which is recommended.  These are usually 2-year
+terms.-->
+
+Steering Committee members serve for [TODO: Service Period] terms, staggered in order to
+preserve continuity. Every year either [TODO:Number] or [TODO:Remainder]
+contributor seats are elected.
+
+<!-- if doing elect-everyone-at-once terms, instead use:
+
+Steering Committee members serve for [TODO: Service Period] terms, elected
+every [TODO: Service Period]
+
+-->
+
+<!-- If you are starting from scratch, and need a transition period, but plan
+to have staggered 2-year terms, we recommend the following:
+
+For the first year of the Steering Committee, [TODO: Year], [TODO: Number] of the
+seats will be elected for a 1-year term, and [TODO: Number] will be elected for
+a 2-year term.
+
+-->
+
+## Election Procedure
+
+### Timeline
+
+Steering Committee elections are held annually. Six weeks or more before the
+election, the Steering Committee will appoint Election Officer(s) (see below).
+Four weeks or more before the election, the Election Officer(s) will issue a
+call for nominations, publish the list of voters, and open the call for
+exceptions. Three days before the election the call for nominations and exceptions
+will be closed. The election will be open for voting not less than two weeks and
+not more than four. The results of the election will be announced within one
+week of closing the election. New Steering Committee members will take office on
+[TODO: Date] of each year.
+
+### Election Officer(s)
+
+Six weeks or more before the election, the Steering Committee will appoint
+between one and three Election Officer(s) to administer the election. Elections
+Officers will be community members in good standing who are eligible to
+vote, are not running for Steering in that election, who are not currently part
+of the Steering Committee and can make a public promise of impartiality. They
+will be responsible for:
+
+- Making all announcements associated with the election
+- Preparing and distributing electronic ballots
+- Judging exception requests
+- Assisting candidates in preparing and sharing statements
+- Tallying voting results according to the rules in this charter
+
+### Eligibility to Vote
+
+Anyone who has at least [TODO:Number] contributions in the last 12 months is
+eligible to vote in the Steering election. Contributions are defined as opening PRs,
+reviewing and commenting on PRs, opening and commenting on issues, writing
+design docs, commenting on design docs, helping people on community forums, participating
+in working groups, and other efforts that help advance the project.
+
+[This dashboard](TODO: Devstats link)
+shows only GitHub based contributions and does not capture all the contributions
+we value. We expect this metric not to capture everyone who should be eligible
+to vote. If a community member has had significant contributions over the past
+year but is not captured in Devstats,
+they will be able to submit an exception form to the Elections Officer(s) who
+will then review and determine whether this member should be eligible to vote.
+All exceptions, and the reasons for them, will be recorded and saved by the
+officers.
+
+<!-- Note: CNCF will soon have a better, GitOps-driven, online election tool
+available.  At that time, projects will want to revise this process. -->
+
+The electoral roll of all eligible voters will be captured at [TODO: Github election
+location] and the voters’ guide will
+be captured at [TODO: Github Election info location],
+similar to the
+[Kubernetes election process](https://github.com/kubernetes/steering/blob/master/elections.md).
+
+We are committed to an inclusive process and will adapt future eligibility
+requirements based on community feedback.
+
+### Candidate Eligibility
+
+Community members must be eligible to vote in order to stand for election (this
+includes voters who qualify for an exception). Candidates may self-nominate or
+be nominated by another eligible member. There are no term limits for Steering
+Committee members. Nothing prevents a qualified member from serving on both Steering
+and other groups simultaneously.
+
+To run for a seat, a candidate must additionally be at least a
+project Member as defined in
+[ROLES.md](TODO: Link to your contributor ladder).
+
+### Voting Procedure
+
+<!-- Note: CNCF will be in a position to offer a more modern replacement for
+CIVS by the end of 2021 -->
+Elections will be held using a time-limited
+[Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on
+[CIVS](http://civs.cs.cornell.edu/) using the IRV method. The top
+vote-getters will be elected to the open seats, with the exceptions for company
+representation discussed below.
+
+### Limitations on Company Representation
+
+No more than [TODO: Number] seats may be held by employees of the same organization (or
+conglomerate, in the case of companies owning each other). If an
+election results in greater than [TODO: Number] employees of the same organization being
+selected, the lowest vote getters from any particular employer will be removed until
+representation on the committee is down to two.
+
+If employers change because of job changes, acquisitions, or other events, in a
+way that would yield too many seats being held by employees of the same
+organization, sufficient members of the committee must resign until only [TODO: Number]
+employees of the same employer are left. If it is impossible to find sufficient
+members to resign, all employees of that organization will be removed and new
+special elections held. In the event of a question of company membership (for
+example evaluating independence of corporate subsidiaries) a majority of all
+non-involved Steering Committee members will decide.
+
+## Vacancies
+
+In the event of a resignation or other loss of an elected SC member, the
+candidate with the next most votes from the previous election will be offered
+the seat, provided that person otherwise qualifies to join the SC. This process
+will continue until the seat is filled.
+
+In case this fails to fill the seat, a special election for that position will
+be held as soon as possible, unless the regular SC election is less than 7 weeks
+away. Eligible voters from the most recent election will vote in the special
+election. Eligibility will not be redetermined at the time of the special
+election. Any replacement SC member will serve out the remainder of the term for
+the person they are replacing, regardless of the length of that remainder.
+
+## Changes to the charter
+
+Changes to this charter may be proposed via a PR on the charter itself.
+Amendments are accepted with majority consent of the committee as per the
+[decision process](#decision-process) outlined above.
+
+Proposals and amendments to the charter are available for at least a period of
+one week for comments and questions before a vote will occur.
+
+## Authority, Facilitation, and Decision Making
+
+Ideally most decisions will be made at the lowest possible level within the
+project: within individual working groups. When this is not possible, Steering
+can help facilitate a conversation to work through the contended issue. When
+facilitation by the SC does not resolve the contention, the SC may have to
+make a decision.
+
+Note that if the committee is called to resolve contended decisions regularly, it is a
+symptom of a larger problem in the community that will need to be addressed.

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -1,0 +1,106 @@
+# Project Governance
+
+This is an example governance document for projects that use the very common
+"maintainer council" system of governance.  See [GOVERNANCE.md](/GOVERNANCE.md)
+for more information.  Thanks to the Jaeger Project for portions of the text
+below.
+
+This is a template document for CNCF projects that requires editing
+before it is ready to use. Read the markdown comments, `<!-- COMMENT -->`, for
+additional guidance. The raw markdown uses `TODO` to identify areas that
+require customization.  Replace [TODO: PROJECTNAME] with the name of your project.
+
+- [Maintainers](#maintainers)
+- [Becoming a Maintainer](#becoming-a-maintainer)
+- [Meetings](#meetings)
+- [CNCF Resources](#cncf-resources)
+- [Code of Conduct Enforcement](#code-of-conduct)
+- [Voting](#voting)
+
+## Maintainers
+
+[TODO: PROJECTNAME] Maintainers have write access to the [project GitHub repository](TODO).
+They can merge their own patches or patches from others. The current maintainers
+can be found in [OWNERS](./OWNERS).  Maintainers collectively manage the project's
+resources and contributors.
+
+This privilege is granted with some expectation of responsibility: maintainers
+are people who care about the [TODO: PROJECTNAME] project and want to help it grow and
+improve. A maintainer is not just someone who can make changes, but someone who
+has demonstrated their ability to collaborate with the team, get the most
+knowledgeable people to review code and docs, contribute high-quality code, and
+follow through to fix issues (in code or tests).
+
+A maintainer is a contributor to the project's success and a citizen helping
+the project succeed.
+
+## Becoming a Maintainer
+
+<!-- If you have full Contributor Ladder documentation that covers becoming
+a Maintainer or Owner, then this section should instead be a reference to that
+documentation -->
+
+To become a Maintainer you need to demonstrate the following:
+
+  * commitment to the project:
+    * participate in discussions, contributions, code and documentation reviews
+      for [TODO: Time Period] or more,
+    * perform reviews for [TODO:Number] non-trivial pull requests,
+    * contribute [TODO:Number] non-trivial pull requests and have them merged,
+  * ability to write quality code and/or documentation,
+  * ability to collaborate with the team,
+  * understanding of how the team works (policies, processes for testing and code review, etc),
+  * understanding of the project's code base and coding and documentation style.
+  <!-- add any additional Maintainer requirements here -->
+
+A new Maintainer must be proposed by an existing maintainer by sending a message to the
+[developer mailing list](TODO: List Link). A simple majority vote of existing Maintainers
+approves the application.
+
+Maintainers who are selected will be granted the necessary GitHub rights,
+and invited to the [private maintainer mailing list](TODO).
+
+## Meetings
+
+Time zones permitting, Maintainers are expected to participate in the public
+developer meeting, which occurs
+[TODO: Details of regular developer or maintainer meeting here].  
+
+Maintainers will also have closed meetings in order to discuss security reports
+or Code of Conduct violations.  Such meetings should be scheduled by any
+Maintainer on receipt of a security issue or CoC report.  All current Maintainers
+must be invited to such closed meetings, except for any Maintainer who is
+accused of a CoC violation.
+
+## CNCF Resources
+
+Any Maintainer may suggest a request for CNCF resources, either in the
+[mailing list](TODO: link to developer/maintainer mailing list), or during a
+meeting.  A simple majority of Maintainers approves the request.  The Maintainers
+may also choose to delegate working with the CNCF to non-Maintainer community
+members.
+
+## Code of Conduct
+
+<!-- This assumes that your project does not have a separate Code of Conduct
+Committee; most maintainer-run projects do not.  Remember to place a link
+to the private Maintainer mailing list or alias in the code-of-conduct file.-->
+
+[Code of Conduct](./code-of-conduct.md)
+violations by community members will be discussed and resolved
+on the [private Maintainer mailing list](TODO).  If the reported CoC violator
+is a Maintainer, the Maintainers will instead designate two Maintainers to work
+with CNCF staff in resolving the report.
+
+## Voting
+
+While most business in [TODO: PROJECTNAME] is conducted by "lazy consensus", periodically
+the Maintainers may need to vote on specific actions or changes.
+A vote can be taken on [the developer mailing list](TODO) or
+[the private Maintainer mailing list](TODO) for security or conduct matters.  
+Votes may also be taken at [the developer meeting](TODO).  Any Maintainer may
+demand a vote be taken.
+
+Most votes require a simple majority of all Maintainers to succeed. Maintainers
+can be removed by a 2/3 majority vote of all Maintainers, and changes to this
+Governance require a 2/3 vote of all Maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,26 @@
+# Project Governance
+
+Because project governance varies widely, we offer several templates covering
+common systems of governance used by various CNCF projects.  In order to
+adopt them, choose the one closest to how you want your project to be governed,
+then rename the appropriate `GOVERNANCE-xxx.md` file to GOVERNANCE.md,
+overwriting this file, and customize it.  
+
+See the Contributor Strategy document on [Leadership Selection](https://github.com/cncf/sig-contributor-strategy/blob/master/governance/docs/leadership_selection.md)
+for more background.  Please also review [SustainOSS's Governance Readiness Checklist](https://sustainers.github.io/governance-readiness/)
+as preparation for making governance decisions.
+
+## Governance Templates Supplied
+
+`GOVERNANCE-maintainer.md` supplies rules for a simple self-selecting council
+of Maintainers as project governance.  It assumes that there is no distinction
+between the contributors who create the majority of code and documentation for
+the project and the group who makes all decisions for the project.  This
+governance is suitable for small, very unified projects, and is often a good
+starting point for project governance.  It is based on the Jaeger project's
+governance.
+
+`GOVERNANCE-elections.md` is a template for an elected steering committee,
+where senior leadership is elected by the body of contributors.  This is a
+suitable structure for larger projects with an established community.  The
+template is based on Kubernetes project governance.


### PR DESCRIPTION
One is for a self-selecting maintainer council
The second is for an elected steering committee.

TODO: create template for "subproject" governance model.

@carolynvs @geekygirldawn @thisisnotapril please review.

The idea here is not to get a perfect example of each form of governance, but rather a generic one that makes for a reasonable jumping off point for projects.