### PR TITLE
Set carolynvs as admin on this repo

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,11 +38,11 @@ collaborators:
   - username: caniszczyk
     permission: admin
 
+  - username: carolynvs
+    permission: admin
+
   # Contributors
   # all permissions except admin
-
-  - username: carolynvs
-    permission: push
 
   - username: mattklein123
     permission: push


### PR DESCRIPTION
We are having drift between the settings file and the actual repo permissions. Bumping myself to admin as requested by Paris so that we can test this out and fix it.