### PR TITLE
Added values to each governance template and improved the README template

### DIFF
--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -20,6 +20,7 @@ the project values and structure.
 This governance  is an open, living document, and will continue to
 evolve as the community and project change.
 
+- [Values](#values)
 - [Charter](#charter)
 - [Delegated authority](#delegated-authority)
 - [Committee Meetings](#committee-meetings)
@@ -36,6 +37,39 @@ evolve as the community and project change.
 - [Vacancies](#vacancies)
 - [Changes to the charter](#changes-to-the-charter)
 - [Authority, Facilitation, and Decision Making](#authority-facilitation-and-decision-making)
+
+## Values
+
+<!-- This is where you put the core values or principles of your project, like
+openness, distributed design, fairness, diversity, etc.
+
+References and Examples
+* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+
+See https://contribute.cncf.io/maintainers/governance/charter for guidance and
+additional examples.  The values below are just example values as a jumping-off
+point for your project's actual values.  -->
+
+The [TODO: PROJECTNAME] and its leadership embrace the following values:
+
+* Openness: Communication happens in the open and is archived for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be heard in a welcoming and respectful environment.
+
+* Participation: Responsibilies within the project are earned through
+  participation, and there is a clear path up the ladder into leadership
+  positions.
+
 
 ## Charter
 

--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -44,7 +44,8 @@ evolve as the community and project change.
 openness, distributed design, fairness, diversity, etc.
 
 References and Examples
-* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+* https://www.apache.org/theapacheway/
+* https://kubernetes.io/community/values/
 
 See https://contribute.cncf.io/maintainers/governance/charter for guidance and
 additional examples.  The values below are just example values as a jumping-off

--- a/GOVERNANCE-elections.md
+++ b/GOVERNANCE-elections.md
@@ -53,7 +53,7 @@ point for your project's actual values.  -->
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication happens in the open and is archived for future
+* Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
@@ -65,10 +65,10 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
   contributor participates in the project as an individual.
 
 * Inclusivity: We innovate through different perspectives and skill sets, which
-  can only be heard in a welcoming and respectful environment.
+  can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilies within the project are earned through
-  participation, and there is a clear path up the ladder into leadership
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
 

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -10,12 +10,45 @@ before it is ready to use. Read the markdown comments, `<!-- COMMENT -->`, for
 additional guidance. The raw markdown uses `TODO` to identify areas that
 require customization.  Replace [TODO: PROJECTNAME] with the name of your project.
 
+- [Values](#values)
 - [Maintainers](#maintainers)
 - [Becoming a Maintainer](#becoming-a-maintainer)
 - [Meetings](#meetings)
 - [CNCF Resources](#cncf-resources)
 - [Code of Conduct Enforcement](#code-of-conduct)
 - [Voting](#voting)
+
+## Values
+
+<!-- This is where you put the core values or principles of your project, like
+openness, distributed design, fairness, diversity, etc.
+
+References and Examples
+* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+
+See https://contribute.cncf.io/maintainers/governance/charter for guidance and
+additional examples.  The values below are just example values as a jumping-off
+point for your project's actual values.  -->
+
+The [TODO: PROJECTNAME] and its leadership embrace the following values:
+
+* Openness: Communication happens in the open and is archived for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be heard in a welcoming and respectful environment.
+
+* Participation: Responsibilies within the project are earned through
+  participation, and there is a clear path up the ladder into leadership
+  positions.
 
 ## Maintainers
 

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -33,7 +33,7 @@ point for your project's actual values.  -->
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication happens in the open and is archived for future
+* Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
@@ -45,10 +45,10 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
   contributor participates in the project as an individual.
 
 * Inclusivity: We innovate through different perspectives and skill sets, which
-  can only be heard in a welcoming and respectful environment.
+  can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilies within the project are earned through
-  participation, and there is a clear path up the ladder into leadership
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
 ## Maintainers

--- a/GOVERNANCE-maintainer.md
+++ b/GOVERNANCE-maintainer.md
@@ -24,7 +24,8 @@ require customization.  Replace [TODO: PROJECTNAME] with the name of your projec
 openness, distributed design, fairness, diversity, etc.
 
 References and Examples
-* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+* https://www.apache.org/theapacheway/
+* https://kubernetes.io/community/values/
 
 See https://contribute.cncf.io/maintainers/governance/charter for guidance and
 additional examples.  The values below are just example values as a jumping-off

--- a/GOVERNANCE-subprojects.md
+++ b/GOVERNANCE-subprojects.md
@@ -42,7 +42,7 @@ point for your project's actual values.  -->
 
 The [TODO: PROJECTNAME] and its leadership embrace the following values:
 
-* Openness: Communication happens in the open and is archived for future
+* Openness: Communication and decision-making happens in the open and is discoverable for future
   reference. As much as possible, all discussions and work take place in public
   forums and open repositories.
 
@@ -54,10 +54,10 @@ The [TODO: PROJECTNAME] and its leadership embrace the following values:
   contributor participates in the project as an individual.
 
 * Inclusivity: We innovate through different perspectives and skill sets, which
-  can only be heard in a welcoming and respectful environment.
+  can only be accomplished in a welcoming and respectful environment.
 
-* Participation: Responsibilies within the project are earned through
-  participation, and there is a clear path up the ladder into leadership
+* Participation: Responsibilities within the project are earned through
+  participation, and there is a clear path up the contributor ladder into leadership
   positions.
 
 ## Individual Project Governance
@@ -208,5 +208,5 @@ from [TODO:PROJECTNAME]. Any Steering Committee member may propose removal of a 
 these grounds, and Steering can confirm this with a majority vote.
 
 Projects which still have contributors will then be moved to a repository in their
-own namespace.  Projects which have ceased all activity are moved to a
+own namespace. Projects which have ceased all activity are moved to a
 [TODO:Name of archive namespace] namespace.

--- a/GOVERNANCE-subprojects.md
+++ b/GOVERNANCE-subprojects.md
@@ -33,7 +33,8 @@ of [TODO:Goals of umbrella project].  Our governance reflects this federated str
 openness, distributed design, fairness, diversity, etc.
 
 References and Examples
-* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+* https://www.apache.org/theapacheway/
+* https://kubernetes.io/community/values/
 
 See https://contribute.cncf.io/maintainers/governance/charter for guidance and
 additional examples.  The values below are just example values as a jumping-off

--- a/GOVERNANCE-subprojects.md
+++ b/GOVERNANCE-subprojects.md
@@ -18,6 +18,47 @@ The [TODO:PROJECTNAME] umbrella project is composed as a federation of individua
 some independent and some interdependent, each of which focuses on some aspect
 of [TODO:Goals of umbrella project].  Our governance reflects this federated structure.
 
+- [Values](#values)
+- [Individual Project Governance](#individual-project-governance)
+- [Steering Committee](#steering-committee)
+  - [Steering Committee Duties](#steering-committee-duties)
+  - [Steering Committee Elections](#steering-committee-elections)
+- [Code of Conduct Committee](#code-of-conduct-committee)
+- [Adding New Subprojects](#adding-new-subprojects)
+- [Removing Projects](#removing-projects)
+
+## Values
+
+<!-- This is where you put the core values or principles of your project, like
+openness, distributed design, fairness, diversity, etc.
+
+References and Examples
+* https://www.apache.org/theapacheway/ https://kubernetes.io/community/values/
+
+See https://contribute.cncf.io/maintainers/governance/charter for guidance and
+additional examples.  The values below are just example values as a jumping-off
+point for your project's actual values.  -->
+
+The [TODO: PROJECTNAME] and its leadership embrace the following values:
+
+* Openness: Communication happens in the open and is archived for future
+  reference. As much as possible, all discussions and work take place in public
+  forums and open repositories.
+
+* Fairness: All stakeholders have the opportunity to provide feedback and submit
+  contributions, which will be considered on their merits.
+
+* Community over Product or Company: Sustaining and growing our community takes
+  priority over shipping code or sponsors' organizational goals.  Each
+  contributor participates in the project as an individual.
+
+* Inclusivity: We innovate through different perspectives and skill sets, which
+  can only be heard in a welcoming and respectful environment.
+
+* Participation: Responsibilies within the project are earned through
+  participation, and there is a clear path up the ladder into leadership
+  positions.
+
 ## Individual Project Governance
 
 <!-- the below assumes that you want to mandate a simple, maintainer-driven

--- a/README-template.md
+++ b/README-template.md
@@ -1,0 +1,103 @@
+# README
+
+The is a README template for CNCF projects. Please start by renaming this to
+README.md and deleting everything up to and including the "template begins here"
+comment in this markdown file.
+
+This is a template document for CNCF projects that requires editing
+before it is ready to use. Read the markdown comments, `<!-- COMMENT -->`, for
+additional guidance. The raw markdown uses `TODO` to identify areas that
+require customization.  Replace [TODO: PROJECTNAME] with the name of your project.
+
+<!-- template begins here-->
+
+# Welcome to the [TODO:Projectname] Project!
+
+<!-- Mission Statement -->
+<!-- More information about crafting your mission statement with examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+[TODO: PROJECTNAME] is a [TODO: Type of Tool] that [TODO: Functions it
+performs].  [TODO: Reasons why these are needed and valuable].  [TODO:
+Implementation, strategy and architecture].
+
+[TODO: Additional paragraph describing your project (optional)]
+
+[TODO: PROJECTNAME] is hosted by the [Cloud Native Computing Foundation (CNCF)](https://cncf.io).
+
+## Getting Started
+
+<!-- Include enough details to get started using, or at least building, the
+project here and link to other docs with more detail as needed.  Depending on
+the nature of the project and its current development status, this might
+include:
+* quick installation/build instructions
+* a few simple examples of use
+* basic prerequisites
+--> 
+
+## Contributing
+<!-- Template: https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md -->
+
+Our project welcomes contributions from any member of our community. To get
+started contributing, please see our [Contributor Guide](TODO: Link to
+CONTRIBUTING.md).
+
+## Scope
+<!-- If this section is too long, you might consider moving it to a SCOPE.md -->
+<!-- More information about creating your scope with links to examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+### In Scope
+
+[TODO: PROJECTNAME] is intended to [TODO: Core functionality]. As such, the
+project will implement or has implemented:
+
+* [TODO: High-level Item 1]
+* [TODO: High-level Item 2]
+* [TODO: High-level Item 3]
+
+
+### Out of Scope
+
+[TODO: PROJECTNAME] will be used in a cloud native environment with other
+tools. The following specific functionality will therefore not be incorporated:
+
+* [TODO: Excluded function 1]
+* [TODO: Excluded function 2]
+
+
+[TODO: PROJECTNAME] implements [TODO: List of major features, existing or
+planned], through [TODO: Implementation
+requirements/language/architecture/etc.]. It will not cover [TODO: short list
+of excluded items]
+
+## Communications
+
+<!-- Fill in the communications channels you actually use.  These should all be public channels anyone
+can join, and there should be several ways that users and contributors can reach project maintainers. 
+If you have recurring/regular meetings, list those or a link to a publicy-readable calendar so that
+prospective contributors know when and where to engage with you. -->
+
+[TODO: Details (with links) to meetings, mailing lists, Slack, and any other communication channels]
+
+* User Mailing List:
+* Developer Mailing List:
+* Slack Channel:
+* Public Meeting Schedule and Links: 
+* Social Media:
+* Other Channel(s), If Any:
+
+## Resources
+
+[TODO: Add links to other helpful information (roadmap, docs, website, etc.)]
+
+## License
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/LICENSE -->
+This project is licensed under [TODO: Add name of license and link to your LICENSE file]
+
+## Conduct
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md -->
+We follow the CNCF Code of Conduct [TODO: Insert link to your CODE_OF_CONDUCT.md file].

--- a/README.md
+++ b/README.md
@@ -28,103 +28,10 @@ when you view the markdown file in GitHub unless you view the raw text.
 
 * [LICENSE](LICENSE)
 * [CONTRIBUTING.md](CONTRIBUTING.md)
-* [README.md](README.md)
+* [README-template.md](README-template.md)
 
 [template-repo]: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
 [contrib-strat]: https://github.com/cncf/sig-contributor-strategy/blob/master/README.md
 
-<!-- TODO: After you have finished customizing the templates, remove this line and everything above
-from the README.md leaving only your finished README content for your project. -->
-
-<!-- Template begins here -->
-
-# Welcome to the [TODO:Projectname] Project!
-
-<!-- Mission Statement -->
-<!-- More information about crafting your mission statement with examples -->
-<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
-
-[TODO: PROJECTNAME] is a [TODO: Type of Tool] that [TODO: Functions it
-performs].  [TODO: Reasons why these are needed and valuable].  [TODO:
-Implementation, strategy and architecture].
-
-[TODO: Additional paragraph describing your project (optional)]
-
-[TODO: PROJECTNAME] is hosted by the [Cloud Native Computing Foundation (CNCF)](https://cncf.io).
-
-## Getting Started
-
-<!-- Include enough details to get started using, or at least building, the
-project here and link to other docs with more detail as needed.  Depending on
-the nature of the project and its current development status, this might
-include:
-* quick installation/build instructions
-* a few simple examples of use
-* basic prerequisites
---> 
-
-## Contributing
-<!-- Template: https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md -->
-
-Our project welcomes contributions from any member of our community. To get
-started contributing, please see our [Contributor Guide](TODO: Link to
-CONTRIBUTING.md).
-
-## Scope
-<!-- If this section is too long, you might consider moving it to a SCOPE.md -->
-<!-- More information about creating your scope with links to examples -->
-<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
-
-### In Scope
-
-[TODO: PROJECTNAME] is intended to [TODO: Core functionality]. As such, the
-project will implement or has implemented:
-
-* [TODO: High-level Item 1]
-* [TODO: High-level Item 2]
-* [TODO: High-level Item 3]
-
-
-### Out of Scope
-
-[TODO: PROJECTNAME] will be used in a cloud native environment with other
-tools. The following specific functionality will therefore not be incorporated:
-
-* [TODO: Excluded function 1]
-* [TODO: Excluded function 2]
-
-
-[TODO: PROJECTNAME] implements [TODO: List of major features, existing or
-planned], through [TODO: Implementation
-requirements/language/architecture/etc.]. It will not cover [TODO: short list
-of excluded items]
-
-## Communications
-
-<!-- Fill in the communications channels you actually use.  These should all be public channels anyone
-can join, and there should be several ways that users and contributors can reach project maintainers. 
-If you have recurring/regular meetings, list those or a link to a publicy-readable calendar so that
-prospective contributors know when and where to engage with you. -->
-
-[TODO: Details (with links) to meetings, mailing lists, Slack, and any other communication channels]
-
-* User Mailing List:
-* Developer Mailing List:
-* Slack Channel:
-* Public Meeting Schedule and Links: 
-* Social Media:
-* Other Channel(s), If Any:
-
-## Resources
-
-[TODO: Add links to other helpful information (roadmap, docs, website, etc.)]
-
-## License
-
-<!-- Template: https://github.com/cncf/project-template/blob/main/LICENSE -->
-This project is licensed under [TODO: Add name of license and link to your LICENSE file]
-
-## Conduct
-
-<!-- Template: https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md -->
-We follow the CNCF Code of Conduct [TODO: Insert link to your CODE_OF_CONDUCT.md file].
+Note: This is the README file for the templates repo. Please use [README-template.md](README-template.md)
+as a template for your project README.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,95 @@ when you view the markdown file in GitHub unless you view the raw text.
 <!-- TODO: After you have finished customizing the templates, remove this line and everything above
 from the README.md leaving only your finished README content for your project. -->
 
----
+<!-- Template begins here -->
 
-# Project Name
+# Welcome to the [TODO:Projectname] Project!
 
-<!-- TODO: Edit the project name heading and include a description of the project -->
+<!-- Mission Statement -->
+<!-- More information about crafting your mission statement with examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+[TODO: PROJECTNAME] is a [TODO: Type of Tool] that [TODO: Functions it
+performs].  [TODO: Reasons why these are needed and valuable].  [TODO:
+Implementation, strategy and architecture].
+
+[TODO: Additional paragraph describing your project (optional)]
+
+[TODO: PROJECTNAME] is hosted by the [Cloud Native Computing Foundation (CNCF)](https://cncf.io).
+
+## Getting Started
+
+<!-- Include enough details to get started using, or at least building, the
+project here and link to other docs with more detail as needed.  Depending on
+the nature of the project and its current development status, this might
+include:
+* quick installation/build instructions
+* a few simple examples of use
+* basic prerequisites
+--> 
+
+## Contributing
+<!-- Template: https://github.com/cncf/project-template/blob/main/CONTRIBUTING.md -->
+
+Our project welcomes contributions from any member of our community. To get
+started contributing, please see our [Contributor Guide](TODO: Link to
+CONTRIBUTING.md).
+
+## Scope
+<!-- If this section is too long, you might consider moving it to a SCOPE.md -->
+<!-- More information about creating your scope with links to examples -->
+<!-- https://contribute.cncf.io/maintainers/governance/charter/ -->
+
+### In Scope
+
+[TODO: PROJECTNAME] is intended to [TODO: Core functionality]. As such, the
+project will implement or has implemented:
+
+* [TODO: High-level Item 1]
+* [TODO: High-level Item 2]
+* [TODO: High-level Item 3]
+
+
+### Out of Scope
+
+[TODO: PROJECTNAME] will be used in a cloud native environment with other
+tools. The following specific functionality will therefore not be incorporated:
+
+* [TODO: Excluded function 1]
+* [TODO: Excluded function 2]
+
+
+[TODO: PROJECTNAME] implements [TODO: List of major features, existing or
+planned], through [TODO: Implementation
+requirements/language/architecture/etc.]. It will not cover [TODO: short list
+of excluded items]
+
+## Communications
+
+<!-- Fill in the communications channels you actually use.  These should all be public channels anyone
+can join, and there should be several ways that users and contributors can reach project maintainers. 
+If you have recurring/regular meetings, list those or a link to a publicy-readable calendar so that
+prospective contributors know when and where to engage with you. -->
+
+[TODO: Details (with links) to meetings, mailing lists, Slack, and any other communication channels]
+
+* User Mailing List:
+* Developer Mailing List:
+* Slack Channel:
+* Public Meeting Schedule and Links: 
+* Social Media:
+* Other Channel(s), If Any:
+
+## Resources
+
+[TODO: Add links to other helpful information (roadmap, docs, website, etc.)]
+
+## License
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/LICENSE -->
+This project is licensed under [TODO: Add name of license and link to your LICENSE file]
+
+## Conduct
+
+<!-- Template: https://github.com/cncf/project-template/blob/main/CODE_OF_CONDUCT.md -->
+We follow the CNCF Code of Conduct [TODO: Insert link to your CODE_OF_CONDUCT.md file].


### PR DESCRIPTION
Adding the values relates to this issue: https://github.com/cncf/tag-contributor-strategy/issues/80

The README improvements were designed to incorporate some of the guidance we've added around [Charter: Mission, Scope, Values, and Principles](https://contribute.cncf.io/maintainers/governance/charter/) along with a few other things that CNCF projects should have in their README files.

Before we ping our TOC reps for review, I'd love to get feedback from the contrib strat team!