### PR TITLE
Automatically sync main back to drafts

### DIFF
--- a/.github/workflows/drafts.yml
+++ b/.github/workflows/drafts.yml
@@ -1,0 +1,19 @@
+name: Sync Drafts Branch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-drafts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Sync Drafts Branch
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: main
+          target_branch: drafts
+          github_token: ${{ github.token }}


### PR DESCRIPTION
When a pull request is merged against main, merge the changes into drafts so that it stays up to date without any manual intervention.