### PR TITLE
Fix contributor template signing instruction link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ The best way to reach us with a question when contributing is to ask on:
 
 ## Sign Your Commits
 
-[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/sign-your-commits)
+[Instructions](https://contribute.cncf.io/maintainers/github/templates/required/contributing/#sign-your-commits)
 
 ⚠️ **Keep either the DCO or CLA section depending on which you use**
 


### PR DESCRIPTION
Fix the sign-off link in the contributor template

Signed-off-by: Terry Howe <tlhowe@amazon.com>