### PR TITLE
Remove obsolete reference to Mishi

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,5 +7,5 @@ We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/mai
     If your project isn't prepared to handle reports, remove the project email address and just have
     reporters send to conduct@cncf.io.
 -->
-Please contact [INSERT EMAIL ADDRESS] or the the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io)
+Please contact [INSERT EMAIL ADDRESS] or the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io)
 in order to report violations of the Code of Conduct.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,9 @@
 We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
 
 <!-- TODO: Decide who will handle Code of Conduct reports and replace [INSERT EMAIL ADDRESS]
-    with an email address in the paragraph below. We recommend using a mailing list to handle reports. 
+    with an email address in the paragraph below. We recommend using a mailing list to handle reports.
+    If your project isn't prepared to handle reports, remove the project email address and just have
+    reporters send to conduct@cncf.io.
 -->
-Please contact [INSERT EMAIL ADDRESS] or the Linux Foundation mediator, Mishi Choudhary mishi@linux.com
-to report an issue.
+Please contact [INSERT EMAIL ADDRESS] or the the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io)
+in order to report violations of the Code of Conduct.


### PR DESCRIPTION
Mishi doesn't handle code of conduct anymore.
add info about CNCF CoCC.